### PR TITLE
Have listenHttp and listenHttps return Node.HTTP.Server

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -35,7 +35,8 @@
     "purescript-eff": "0.1.x",
     "purescript-lists": "0.7.x",
     "purescript-data-default": "0.1.0",
-    "purescript-unfoldable": "0.4.0"
+    "purescript-unfoldable": "0.4.0",
+    "purescript-node-http": "0.1.6"
   },
   "devDependencies": {
     "purescript-console": "0.1.x",

--- a/examples/src/Capture.purs
+++ b/examples/src/Capture.purs
@@ -14,6 +14,7 @@ import qualified Node.FS.Async as F
 import Node.Express.Types
 import Node.Express.App
 import Node.Express.Handler
+import Node.HTTP (Server())
 
 
 indexHandler :: Handler
@@ -32,6 +33,6 @@ sendContentsHandler eitherContents =
 appSetup :: App
 appSetup = get  "/" indexHandler
 
-main :: forall e. Eff (express :: Express | e) Unit
+main :: forall e. Eff (express :: Express | e) Server
 main = do
     listenHttp appSetup 8080 \_ -> log $ "Listening on 8080"

--- a/examples/src/JSMiddleware.purs
+++ b/examples/src/JSMiddleware.purs
@@ -9,6 +9,7 @@ import Control.Monad.Eff.Console (log)
 import Node.Express.Types
 import Node.Express.App
 import Node.Express.Handler
+import Node.HTTP (Server())
 
 
 foreign import jsonBodyParser :: Fn3 Request Response (ExpressM Unit) (ExpressM Unit)
@@ -29,6 +30,6 @@ appSetup = do
     get  "/" indexHandler
     post "/" echoHandler
 
-main :: forall e. Eff (express :: Express | e) Unit
+main :: forall e. Eff (express :: Express | e) Server
 main = do
     listenHttp appSetup 8080 \_ -> log $ "Listening on 8080"

--- a/examples/src/ToDoServer.purs
+++ b/examples/src/ToDoServer.purs
@@ -12,6 +12,7 @@ import Control.Monad.ST
 import Node.Express.Types
 import Node.Express.App
 import Node.Express.Handler
+import Node.HTTP (Server())
 
 
 -- Pretend for now that this is our cool database (:
@@ -131,7 +132,7 @@ appSetup = do
     get "/done/:id" doTodoHandler
     useOnError errorHandler
 
-main :: forall e. Eff (express :: Express | e) Unit
+main :: forall e. Eff (express :: Express | e) Server
 main = do
     port <- unsafeForeignFunction [""] "process.env.PORT || 8080"
     listenHttp appSetup port \_ ->

--- a/src/Node/Express/App.purs
+++ b/src/Node/Express/App.purs
@@ -15,10 +15,12 @@ import Control.Monad.Eff
 import Control.Monad.Eff.Class
 import Control.Monad.Eff.Exception
 import Control.Monad.Eff.Unsafe
+import Node.HTTP (Server ())
 
 import Node.Express.Types
 import Node.Express.Internal.App
 import Node.Express.Handler
+
 
 
 --| Monad responsible for application related operations (initial setup mostly).
@@ -51,7 +53,7 @@ instance monadEffAppM :: MonadEff eff AppM where
 
 --| Run application on specified port and execute callback after launch.
 --| HTTP version
-listenHttp :: forall e. App -> Port -> (Event -> Eff e Unit) -> ExpressM Unit
+listenHttp :: forall e. App -> Port -> (Event -> Eff e Unit) -> ExpressM Server
 listenHttp (AppM act) port cb = do
     app <- intlMkApplication
     act app
@@ -59,7 +61,7 @@ listenHttp (AppM act) port cb = do
 
 --| Run application on specified port and execute callback after launch.
 --| HTTPS version
-listenHttps :: forall e opts. App -> Port -> opts -> (Event -> Eff e Unit) -> ExpressM Unit
+listenHttps :: forall e opts. App -> Port -> opts -> (Event -> Eff e Unit) -> ExpressM Server
 listenHttps (AppM act) port opts cb = do
     app <- intlMkApplication
     act app

--- a/src/Node/Express/Internal/App.js
+++ b/src/Node/Express/Internal/App.js
@@ -10,9 +10,11 @@ exports.intlAppListenHttp = function(app) {
         return function(cb) {
             return function() {
                 var http = module.require('http');
-                http.createServer(app).listen(port, function(e) {
+                var server = http.createServer(app);
+                server.listen(port, function(e) {
                     return cb(e)();
                 });
+                return server;
             }
         }
     }
@@ -24,9 +26,11 @@ exports.intlAppListenHttps = function(app) {
             return function(cb) {
                 return function() {
                     var https = module.require('https');
-                    https.createServer(opts, app).listen(port, function(e) {
+                    var server = https.createServer(opts, app);
+                    server.listen(port, function(e) {
                         return cb(e)();
                     });
+                    return server;
                 }
             }
         }

--- a/src/Node/Express/Internal/App.purs
+++ b/src/Node/Express/Internal/App.purs
@@ -12,7 +12,7 @@ import Control.Monad.Eff.Exception
 import Node.Express.Types
 import Node.Express.Internal.Utils
 import Node.Express.Handler
-
+import Node.HTTP (Server())
 
 foreign import intlMkApplication :: ExpressM Application
 
@@ -40,10 +40,10 @@ intlAppHttp = unsafeForeignProcedure ["app", "method", "route", "cb", ""]
     "app[method](route, function(req, resp, next) { return cb(req)(resp)(next)(); })"
 
 foreign import intlAppListenHttp :: forall e.
-    Application -> Int -> (Event -> Eff e Unit) -> ExpressM Unit
+    Application -> Int -> (Event -> Eff e Unit) -> ExpressM Server
 
 foreign import intlAppListenHttps :: forall opts e.
-    Application -> Int -> opts -> (Event -> Eff e Unit) -> ExpressM Unit
+    Application -> Int -> opts -> (Event -> Eff e Unit) -> ExpressM Server
 
 
 intlAppUse ::


### PR DESCRIPTION
Hey,

I was trying to start a SocketIO server on top of the express server, but the current implementation wasn't passing it back. I added a dependency on Node.HTTP and had listenHttp and listenHttps return the server object.