### PR TITLE
Add getBody function.

### DIFF
--- a/src/Node/Express/Request.js
+++ b/src/Node/Express/Request.js
@@ -12,6 +12,12 @@ exports._getRoute = function (req) {
     };
 };
 
+exports._getBody = function (req) {
+    return function () {
+        return req.body == null ? void 0 : req.body;
+    };
+};
+
 exports._getBodyParam = function (req, name) {
     return function () {
         return req.body == null ? void 0 : req.body[name];

--- a/src/Node/Express/Request.purs
+++ b/src/Node/Express/Request.purs
@@ -12,7 +12,7 @@ module Node.Express.Request
     ) where
 
 import Prelude
-import Data.Foreign (Foreign)
+import Data.Foreign (Foreign, MultipleErrors)
 import Data.Foreign.Class (class IsForeign, read)
 import Data.Function.Uncurried (Fn2(), Fn3(), runFn2, runFn3)
 import Data.Either (Either(..))

--- a/src/Node/Express/Request.purs
+++ b/src/Node/Express/Request.purs
@@ -1,6 +1,6 @@
 module Node.Express.Request
-    ( getRouteParam, getQueryParam, getQueryParams, getBodyParam
-    , getRoute
+    ( getRouteParam, getQueryParam, getQueryParams, getBody
+    , getBodyParam, getRoute
     , getCookie, getSignedCookie
     , getRequestHeader
     , accepts, ifAccepts, acceptsCharset, acceptsLanguage, hasType
@@ -33,6 +33,13 @@ import Node.Express.Internal.QueryString (Param, parse, getAll, getOne)
 getRouteParam :: forall e a. (RequestParam a) => a -> HandlerM (express :: EXPRESS | e) (Maybe String)
 getRouteParam name = HandlerM \req _ _ ->
     liftEff $ liftM1 (eitherToMaybe <<< runExcept <<< read) (runFn2 _getRouteParam req name)
+
+-- | Get the request's body.
+-- | NOTE: Not parsed by default, you must attach proper middleware
+-- |       See http://expressjs.com/4x/api.html#req.body
+getBody :: forall e a. (IsForeign a) => HandlerM (express :: EXPRESS | e) (Either MultipleErrors a)
+getBody = HandlerM \req _ _ ->
+    liftEff $ liftM1 (runExcept <<< read) (_getBody req)
 
 -- | Get param from request's body.
 -- | NOTE: Not parsed by default, you must attach proper middleware
@@ -185,6 +192,8 @@ queryParams req = do
 foreign import _getRouteParam :: forall e a. Fn2 Request a (ExpressM e Foreign)
 
 foreign import _getRoute :: forall e. Request -> ExpressM e String
+
+foreign import _getBody :: forall e. Request -> ExpressM e Foreign
 
 foreign import _getBodyParam :: forall e. Fn2 Request String (ExpressM e Foreign)
 

--- a/test/Test/Mock.purs
+++ b/test/Test/Mock.purs
@@ -4,6 +4,7 @@ module Test.Mock
     , MockCookie(..)
     , setRequestHeader
     , setRouteParam
+    , setBody
     , setBodyParam
     , setRequestCookie
     , setRequestSignedCookie
@@ -25,25 +26,25 @@ module Test.Mock
     , assertTestHeader
     ) where
 
-import Control.Monad.Aff (Aff, launchAff)
 import Control.Monad.Eff
 import Control.Monad.Eff.Class
-import Control.Monad.Eff.Exception (EXCEPTION)
 import Control.Monad.Cont.Trans
 import Control.Monad.Except.Trans
 import Control.Monad.Reader.Trans
-import Data.Function hiding (apply)
 import Data.Maybe
-import Data.StrMap as StrMap
 import Data.Tuple
 import Node.Express.App
 import Node.Express.Handler
 import Node.Express.Types
 import Node.Express.Response
-import Prelude hiding (apply)
 import Test.Unit
 import Test.Unit.Console
 import Test.Unit.Assert
+import Data.StrMap as StrMap
+import Control.Monad.Aff (Aff, launchAff)
+import Control.Monad.Eff.Exception (EXCEPTION)
+import Data.Function hiding (apply)
+import Prelude hiding (apply)
 
 type MockCookie =
     { name    :: String
@@ -60,6 +61,7 @@ type MockResponse =
 
 newtype MockRequest = MockRequest
     { setHeader :: String -> String -> MockRequest
+    , setBody :: String -> MockRequest
     , setBodyParam :: String -> String -> MockRequest
     , setRouteParam :: String -> String -> MockRequest
     , setCookie :: String -> String -> MockRequest
@@ -68,6 +70,9 @@ newtype MockRequest = MockRequest
 
 setRequestHeader :: String -> String -> MockRequest -> MockRequest
 setRequestHeader name value (MockRequest r) = r.setHeader name value
+
+setBody :: String -> MockRequest -> MockRequest
+setBody value (MockRequest r) = r.setBody value
 
 setBodyParam :: String -> String -> MockRequest -> MockRequest
 setBodyParam name value (MockRequest r) = r.setBodyParam name value

--- a/testJs/MockRequest.js
+++ b/testJs/MockRequest.js
@@ -28,6 +28,13 @@ MockRequest.prototype.setHeader = function(headerName) {
     };
 }
 
+// String -> MockRequest
+MockRequest.prototype.setBody = function(value) {
+    var self = this;
+    self.body = value;
+    return self;
+}
+
 // String -> String -> MockRequest
 MockRequest.prototype.setBodyParam = function(paramName) {
     var self = this;


### PR DESCRIPTION
What do you think of this change?

I want to have a body like this: `"{name: 'Alfred', salary: 1000}"`, and I want to parse it into a type like this: `newtype PersonRec = PersonRec { name :: String, salary :: Number}`. I can't use `getBodyParam`, because what param do I get? So I'm forced to use a wrapper object and key, like this: `"{person: {name: 'Alfred', salary: 1000}}"`.

Also note this difference with `getBodyParam`: I didn't use `eitherToMaybe` because I want to know how the parsing failed, if it did. I got really confused when the value was Nothing - I thought I didn't send the param at all, when I actually did. If this function returned `Either MultipleErrors a`, then I am able to see the parse errors. I think we should do this to `getBodyParam`, also, but it would be a breaking change.

_update: I fixed the build - needed to kill output directory. Discovered I needed to add import._