### PR TITLE
Add alternatives to all route verbs which accept middlewares.

### DIFF
--- a/src/Node/Express/App.js
+++ b/src/Node/Express/App.js
@@ -45,6 +45,16 @@ exports._http = function (app, method, route, handler) {
     };
 };
 
+exports._httpMw = function (app, method, route, handlers) {
+    return function () {
+        app[method](route, handlers.map(function(f) {
+            return function(req, res, next) {
+                return f(req)(res)(next)();
+            }
+        }));
+    };
+};
+
 exports._use = function (app, mw) {
     return function () {
         app.use(function(req, resp, next) {


### PR DESCRIPTION
This solves the problem I was having here: https://github.com/dancingrobot84/purescript-express/issues/55

Instead of trying to do monadic middleware binding, I just pass an array of middlewares to be processed by the route.

```
  let smallMiddlewares = [authenticationRequired, logUserConnection]
  putMw url (smallMiddlewares <> [bigHandlerFn])
```

What are your thoughts on this strategy? Here's the express docs on this feature: http://expressjs.com/en/4x/api.html#middleware-callback-function-examples