### PR TITLE
Added response.end() method & moved the Test.unit package into bower dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -40,13 +40,13 @@
     "purescript-strings": "^3.0.0",
     "purescript-transformers": "^3.2.0",
     "purescript-unfoldable": "^3.0.0",
-    "purescript-foreign-generic": "^4.1.0"
+    "purescript-foreign-generic": "^4.1.0",
+    "purescript-test-unit": "^11.0.0"
   },
   "devDependencies": {
     "purescript-console": "^3.0.0",
     "purescript-maps": "^3.0.0",
     "purescript-node-fs": "^4.0.0",
-    "purescript-test-unit": "^11.0.0",
     "purescript-unsafe-coerce": "^3.0.0"
   }
 }

--- a/src/Node/Express/Response.js
+++ b/src/Node/Express/Response.js
@@ -54,6 +54,13 @@ exports._send = function (resp, data) {
     };
 };
 
+exports._end = function (resp) {
+    return function () {
+        resp.end();
+    };
+};
+
+
 exports._sendJson = function (resp, data) {
     return function () {
         resp.json(data);
@@ -111,4 +118,3 @@ exports._render = function (res, view, data) {
         return res.render(view, data);
     };
 };
-

--- a/src/Node/Express/Response.purs
+++ b/src/Node/Express/Response.purs
@@ -6,6 +6,7 @@ module Node.Express.Response
     , redirect, redirectWithStatus, setLocation
     , sendFile, sendFileExt, download, downloadExt
     , render
+    , end
     ) where
 
 import Prelude
@@ -49,6 +50,10 @@ setCookie name val opts = HandlerM \_ resp _ ->
 clearCookie :: forall e. String -> String -> Handler e
 clearCookie name path = HandlerM \_ resp _ ->
     liftEff $ runFn3 _clearCookie resp name path
+
+-- | Ends the response process.
+end :: forall e. Handler e
+end = HandlerM \_ resp _ -> liftEff $ _end resp
 
 -- | Send a response. Could be object, string, buffer, etc.
 send :: forall e a. a -> Handler e
@@ -127,6 +132,8 @@ foreign import _setCookie :: forall e. Fn4 Response String String CookieOptions 
 
 foreign import _clearCookie :: forall e. Fn3 Response String String (ExpressM e Unit)
 
+foreign import _end :: forall e. Response -> (ExpressM e Unit)
+
 foreign import _send :: forall e a. Fn2 Response a (ExpressM e Unit)
 
 foreign import _sendJson :: forall e a. Fn2 Response a (ExpressM e Unit)
@@ -146,4 +153,3 @@ foreign import _downloadExt :: forall e. Fn4 Response String String (Error -> Ex
 foreign import _headersSent :: forall e. Response -> ExpressM e Boolean
 
 foreign import _render :: forall e a. Fn3 Response String a (ExpressM e Unit)
-

--- a/src/Node/Express/Test/Mock.js
+++ b/src/Node/Express/Test/Mock.js
@@ -165,6 +165,11 @@ MockResponse.prototype.send = function(data) {
     this.headersSent = true;
 }
 
+MockResponse.prototype.end = function() {
+    this.statusCode = 200;
+    this.headersSent = true;
+}
+
 MockResponse.prototype.json = function(obj) {
    this.send(JSON.stringify(obj));
 }
@@ -381,4 +386,3 @@ exports.sendMockError = function(mockApp) {
         };
     };
 }
-

--- a/test/Test/Handler.purs
+++ b/test/Test/Handler.purs
@@ -240,6 +240,12 @@ testResponse = do
         setupMockApp $ use $ send testValue
         sendTestRequest id $ assertData testValue
 
+    testExpress "end" $ do
+        setupMockApp $ use $ setStatus 200
+        setupMockApp $ use end
+        sendTestRequest id $ \response -> do
+            assertStatusCode 200 response
+
     testExpress "sendJson" $ do
         setupMockApp $ use $ sendJson testData
         sendTestRequest id $ assertData testDataStr

--- a/test/Test/Handler.purs
+++ b/test/Test/Handler.purs
@@ -241,7 +241,6 @@ testResponse = do
         sendTestRequest id $ assertData testValue
 
     testExpress "end" $ do
-        setupMockApp $ use $ setStatus 200
         setupMockApp $ use end
         sendTestRequest id $ \response -> do
             assertStatusCode 200 response


### PR DESCRIPTION
I moved the Test.unit package into bower dependencies because without it there you get this [build error](https://github.com/dancingrobot84/purescript-express/issues/66) another option was to move the Node.Express.Test.Mock module into the tests directory. I didn't go down that route because from earlier commits it seemed to have been moved into the src folder on purpose.